### PR TITLE
Add strict mode for older node compatibility

### DIFF
--- a/csv-parser.js
+++ b/csv-parser.js
@@ -1,3 +1,5 @@
+"use strict";
+
 class CsvParser {
     // ref: http://stackoverflow.com/a/1293163/2343
     // This will parse a delimited string into an array of

--- a/flood-data.js
+++ b/flood-data.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const http = require("http");
 const fs = require('fs');
 var xlsx = require('xlsx');

--- a/flood-event.js
+++ b/flood-event.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const parser = require("./parsers");
 
 class FloodEvent {

--- a/flood-stats.js
+++ b/flood-stats.js
@@ -1,5 +1,6 @@
-const Enumerable = require("linq");
+"use strict";
 
+const Enumerable = require("linq");
 
 class FloodStatsGenerator {
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const http = require("http");
 const express = require("express");
 var FloodData = require('./flood-data');


### PR DESCRIPTION
Add "use strict"; to javascript files, because node v4 gives the following complaint:

> SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode